### PR TITLE
Show help when no argument supplied + some ES6 improvements

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,11 +2,17 @@
 'use strict';
 var meow = require('meow');
 var fetchManifestJson = require('./');
-
 var cli = meow([
 	'Usage',
 	'  $ fetch-manifest-json [URL]',
-	'',
+	'Example',
 	'  $ fetch-manifest-json https://jsfeatures.in'
 ]);
-fetchManifestJson(cli.input[0]).then(p => console.log(p))
+
+//If no argument is supplied then show help
+if(cli.input.length === 0) {
+	console.log(cli.help);
+	process.exit(0);
+}
+
+fetchManifestJson(cli.input[0]).then(p => console.log(p)).catch(err => console.log(err))

--- a/cli.js
+++ b/cli.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
-var meow = require('meow');
-var fetchManifestJson = require('./');
-var cli = meow([
+const meow = require('meow');
+const fetchManifestJson = require('./');
+const cli = meow([
 	'Usage',
 	'  $ fetch-manifest-json [URL]',
 	'Example',
@@ -15,4 +15,4 @@ if(cli.input.length === 0) {
 	process.exit(0);
 }
 
-fetchManifestJson(cli.input[0]).then(p => console.log(p)).catch(err => console.log(err))
+fetchManifestJson(cli.input[0]).then(p => console.log(p))

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const got = require('got');
 const debug = require('debug')('manifest');
 const xray = require('x-ray')();
 
-module.exports = function (appUrl) {
-  return new Promise(function (resolve, reject) {
+module.exports = appUrl => {
+  return new Promise((resolve, reject) => {
         xray(appUrl, 'link[rel=manifest]@href')(function (err, manifestTarget) {
             debug(err, manifestTarget);
 
@@ -16,7 +16,7 @@ module.exports = function (appUrl) {
                 manifestTarget: manifestTarget
             });
         });
-    }).then((result) => {
+    }).then(result => {
         if (result.manifestTarget) {
           // found manifest via html
             return got(result.manifestTarget);

--- a/index.js
+++ b/index.js
@@ -16,15 +16,15 @@ module.exports = function (appUrl) {
                 manifestTarget: manifestTarget
             });
         });
-    }).then(function (result) {
+    }).then((result) => {
         if (result.manifestTarget) {
           // found manifest via html
             return got(result.manifestTarget);
-        } 
+        }
         // no manifest in html, fetch at root
         return got(appUrl + '/manifest.json');
-        
-    }).then(function (result) {
+
+    }).then(result => {
         var manifestResponse = result.body;
         var manifestJson = null;
         try {
@@ -35,7 +35,7 @@ module.exports = function (appUrl) {
 
         return manifestJson;
     })
-    .catch(function (err) {
+    .catch(err => {
         throw err;
     });
 };

--- a/package.json
+++ b/package.json
@@ -28,10 +28,8 @@
     "manifest-json"
   ],
   "dependencies": {
-    "chalk": "^1.1.3",
     "got": "^6.3.0",
     "meow": "^3.7.0",
-    "ora": "^0.2.3",
     "x-ray": "^2.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
     "manifest-json"
   ],
   "dependencies": {
+    "chalk": "^1.1.3",
     "got": "^6.3.0",
     "meow": "^3.7.0",
+    "ora": "^0.2.3",
     "x-ray": "^2.3.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 
 ## Install
 
-```
+``` sh
 $ npm install --save fetch-manifest-json
 ```
 
@@ -20,38 +20,38 @@ fetchManifestJson(<URL>).then(console.log).catch(console.error);
 
 ## CLI
 
-```
+``` sh
 $ npm install --global fetch-manifest-json
 ```
 
-```
+``` sh
 $ fetch-manifest-json --help
 
-  Usage
-    fetch-manifest-json [URL]
+	Usage
+		fetch-manifest-json [URL]
 
-  Examples
-    $ fetch-manifest-json https://jsfeatures.in
+	Example
+		$ fetch-manifest-json https://jsfeatures.in
 
-    { name: 'JSfeatures.in',
-      short_name: 'JSfeatures',
-      icons: 
-       [ { src: 'images/touch/icon-128x128.png',
-           sizes: '128x128',
-           type: 'image/png' },
-         { src: 'images/touch/apple-touch-icon.png',
-           sizes: '152x152',
-           type: 'image/png' },
-         { src: 'images/touch/ms-touch-icon-144x144-precomposed.png',
-           sizes: '144x144',
-           type: 'image/png' },
-         { src: 'images/touch/chrome-touch-icon-192x192.png',
-           sizes: '192x192',
-           type: 'image/png' } ],
-      start_url: '/',
-      display: 'standalone',
-      background_color: '#3E4EB8',
-      theme_color: '#00BCD4' } 
+		{ name: 'JSfeatures.in',
+			short_name: 'JSfeatures',
+			icons:
+			 [ { src: 'images/touch/icon-128x128.png',
+					 sizes: '128x128',
+					 type: 'image/png' },
+				 { src: 'images/touch/apple-touch-icon.png',
+					 sizes: '152x152',
+					 type: 'image/png' },
+				 { src: 'images/touch/ms-touch-icon-144x144-precomposed.png',
+					 sizes: '144x144',
+					 type: 'image/png' },
+				 { src: 'images/touch/chrome-touch-icon-192x192.png',
+					 sizes: '192x192',
+					 type: 'image/png' } ],
+			start_url: '/',
+			display: 'standalone',
+			background_color: '#3E4EB8',
+			theme_color: '#00BCD4' }
 ```
 
 P.S: This module is extracted from [PWAify](https://github.com/vladikoff/PWAify)


### PR DESCRIPTION
Now when no argument is supplied to our command .It will show output that would be produced by help command.

``` sh
$ fetch-manifest-json

 Fetch manifest.json from a PWA.

  Usage
    $ fetch-manifest-json [URL]
  Example
    $ fetch-manifest-json https://jsfeatures.in

```

Plus some ES6 style code fixes like using const for module loading and using arrow functions.

@hemanth :tanabata_tree: 
